### PR TITLE
Fix for JSTypedArrayType crash

### DIFF
--- a/Source/Ejecta/EJConvertTypedArray.m
+++ b/Source/Ejecta/EJConvertTypedArray.m
@@ -128,13 +128,13 @@ static JSValueRef GetPropertyNamed(JSContextRef ctx, JSObjectRef object, const c
 // Shorthand to get the Constructor for the given JSTypedArrayType
 
 static JSObjectRef GetConstructor(JSContextRef ctx, JSTypedArrayType type) {
-	if( type <= kJSTypedArrayTypeNone || type > kJSTypedArrayTypeArrayBuffer ) {
-		return NULL;
-	}
-	
-	const char *constructorName = TypeInfo[type].constructorName;
-	JSObjectRef global = JSContextGetGlobalObject(ctx);
-	return (JSObjectRef)GetPropertyNamed(ctx, global, constructorName);
+    if( type == kJSTypedArrayTypeNone || type == kJSTypedArrayTypeArrayBuffer ) {
+        return NULL;
+    }
+    
+    const char *constructorName = TypeInfo[type].constructorName;
+    JSObjectRef global = JSContextGetGlobalObject(ctx);
+    return (JSObjectRef)GetPropertyNamed(ctx, global, constructorName);
 }
 
 
@@ -258,13 +258,13 @@ void JSContextPrepareTypedArrayAPI(JSContextRef ctx) {
 	// Install the __ejTypedArrayType property on each Typed Array prototype
 	JSStringRef jsTypeName = JSStringCreateWithUTF8CString("__ejTypedArrayType");
 	
-	for( int type = kJSTypedArrayTypeInt8Array; type <= kJSTypedArrayTypeArrayBuffer; type++ ) {
-		JSObjectRef jsConstructor = GetConstructor(ctx, type);
-		JSObjectRef jsPrototype = (JSObjectRef)GetPropertyNamed(ctx, jsConstructor, "prototype");
-		
-		JSValueRef jsType = MakeInt32(ctx, type);
-		JSObjectSetProperty(ctx, jsPrototype, jsTypeName, jsType, attributes, NULL);
-	}
+    for( int type = kJSTypedArrayTypeInt8Array; type < kJSTypedArrayTypeArrayBuffer; type++ ) {
+        JSObjectRef jsConstructor = GetConstructor(ctx, type);
+        JSObjectRef jsPrototype = (JSObjectRef)GetPropertyNamed(ctx, jsConstructor, "prototype");
+        
+        JSValueRef jsType = MakeInt32(ctx, type);
+        JSObjectSetProperty(ctx, jsPrototype, jsTypeName, jsType, attributes, NULL);
+    }
 	
 	JSStringRelease(jsTypeName);
 	


### PR DESCRIPTION
Apple changed the order of the JSTypedArrayType enumeration,

Ejecta code was assuming the `None` and the `Buffer` values were the min , max.

Caused a crash on view port when trying to construct `JSObjectRef`, because it would return `NULL` during a `for` loop on the `JSTypedArrayType` enum (see code changes).

@SRandazzo @udipl 
