### PR TITLE
Fix for iOS 14 number crash

### DIFF
--- a/Source/Ejecta/EJConvert.m
+++ b/Source/Ejecta/EJConvert.m
@@ -28,33 +28,8 @@ JSValueRef NSStringToJSValue( JSContextRef ctx, NSString *string ) {
 // and is thus a lot slower.
 
 double JSValueToNumberFast(JSContextRef ctx, JSValueRef v) {
-	#if __LP64__ // arm64 version
-		union {
-			int64_t asInt64;
-			double asDouble;
-			struct { int32_t asInt; int32_t tag; } asBits;
-		} taggedValue = { .asInt64 = (int64_t)v };
-		
-		#define DoubleEncodeOffset 0x1000000000000ll
-		#define TagTypeNumber 0xffff0000
-		#define ValueTrue 0x7
-		
-		if( (taggedValue.asBits.tag & TagTypeNumber) == TagTypeNumber ) {
-			return taggedValue.asBits.asInt;
-		}
-		else if( taggedValue.asBits.tag & TagTypeNumber ) {
-			taggedValue.asInt64 -= DoubleEncodeOffset;
-			return taggedValue.asDouble;
-		}
-		else if( taggedValue.asBits.asInt == ValueTrue ) {
-			return 1.0;
-		}
-		else {
-			return 0; // false, undefined, null, object
-		}
-	#else // armv7 version
-		return JSValueToNumber(ctx, v, NULL);
-	#endif
+    // The previous implementation does not work on iOS 14+. We use the above Apple Provided implemenation now instead.
+    return JSValueToNumber(ctx, v, NULL);
 }
 
 void JSValueUnprotectSafe( JSContextRef ctx, JSValueRef v ) {

--- a/Source/Ejecta/EJConvert.m
+++ b/Source/Ejecta/EJConvert.m
@@ -28,7 +28,7 @@ JSValueRef NSStringToJSValue( JSContextRef ctx, NSString *string ) {
 // and is thus a lot slower.
 
 double JSValueToNumberFast(JSContextRef ctx, JSValueRef v) {
-    // The previous implementation does not work on iOS 14+. We use the Apple Provided implemenation now instead.
+    // The previous implementation does not work on iOS 14+. We use the Apple Provided implementation now instead.
     return JSValueToNumber(ctx, v, NULL);
 }
 

--- a/Source/Ejecta/EJConvert.m
+++ b/Source/Ejecta/EJConvert.m
@@ -28,7 +28,7 @@ JSValueRef NSStringToJSValue( JSContextRef ctx, NSString *string ) {
 // and is thus a lot slower.
 
 double JSValueToNumberFast(JSContextRef ctx, JSValueRef v) {
-    // The previous implementation does not work on iOS 14+. We use the above Apple Provided implemenation now instead.
+    // The previous implementation does not work on iOS 14+. We use the Apple Provided implemenation now instead.
     return JSValueToNumber(ctx, v, NULL);
 }
 


### PR DESCRIPTION
The custom method for transforming JS numbers fails on iOS 14